### PR TITLE
[FEAT] Adding Code Coverage Utils

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -38,6 +38,18 @@
         "CMAKE_C_FLAGS": "-ftime-trace",
         "CMAKE_CXX_FLAGS": "-ftime-trace"
       }
+    },  
+    {
+      "name": "rocm-cov",
+      "description": "Build with ROCm and gcov for code coverage",
+      "inherits": ["rocm-llvm"],
+      "cacheVariables": {
+        "BUILD_TYPE": "Debug",
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_C_FLAGS":   "-O0 -g3 -ggdb -fprofile-instr-generate -fcoverage-mapping -Wl,--allow-multiple-definition",
+        "CMAKE_CXX_FLAGS": "-O0 -g3 -ggdb -fprofile-instr-generate -fcoverage-mapping -Wl,--allow-multiple-definition",
+        "CMAKE_HIP_FLAGS": "-O0 -g3 -ggdb -fprofile-instr-generate -fcoverage-mapping -Wl,--allow-multiple-definition"
+      }
     }
   ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -41,7 +41,7 @@
     },  
     {
       "name": "rocm-cov",
-      "description": "Build with ROCm and gcov for code coverage",
+      "description": "Build with ROCm and llvm-cov for code coverage",
       "inherits": ["rocm-llvm"],
       "cacheVariables": {
         "BUILD_TYPE": "Debug",

--- a/docker/Dockerfile.ci_gpu_rocm
+++ b/docker/Dockerfile.ci_gpu_rocm
@@ -40,7 +40,8 @@ ARG ARG_GPU_BUILD_TARGETS="gfx90a,gfx942"
 ENV GPU_BUILD_TARGETS=${ARG_GPU_BUILD_TARGETS}
 
 ENV DGL_BUILD_DIR="${DGL_SRC_DIR}/build"
-ENV DGL_ARTIFACTS_DIR="/tmp/artifacts"
+ARG ARG_DGL_ARTIFACTS_DIR="/artifacts"
+ENV DGL_ARTIFACTS_DIR="${ARG_DGL_ARTIFACTS_DIR}"
 
 # Install GraphBolt dependencies
 RUN mkdir -p /tmp/deps && cd /tmp/deps && bash ${DGL_SRC_DIR}/script/install_graphbolt_deps.sh

--- a/graphbolt/CMakeLists.txt
+++ b/graphbolt/CMakeLists.txt
@@ -156,7 +156,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
     ExternalProject_Add(
       liburing
       SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../third_party/liburing
-      CONFIGURE_COMMAND <SOURCE_DIR>/configure --cc=${LIBURING_C_COMPILER} --cxx=${CMAKE_CXX_COMPILER} --prefix=/
+      CONFIGURE_COMMAND <SOURCE_DIR>/configure --cc=${LIBURING_C_COMPILER} --cxx=${CMAKE_CXX_COMPILER} --prefix=/ --use-libc
       # In order to avoid the error `error: redefinition of 'struct in6_pktinfo'` on ubi7
       # when building examples, let's build src only.
       BUILD_COMMAND bash -c "make -j 4 -C src/"

--- a/script/run_code_cov.sh
+++ b/script/run_code_cov.sh
@@ -57,7 +57,7 @@ ${DGL_DIR}/build/runUnitTests
 ################################################################################
 
 # TODO do we want to collect graphbolt coverage here if we are skipping other third party libraries?
-BINARIES="${DGL_DIR}/build/libdgl.so ${DGL_DIR}/build/graphbolt/libgraphbolt_pytorch_2.6.0.so"
+BINARIES="${DGL_DIR}/build/libdgl.so"
 
 # Collect all the profraw files
 find . -type f -name "*.profraw" > rawprofiles.list

--- a/script/run_code_cov.sh
+++ b/script/run_code_cov.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+################################################################################
+# Setup and checks
+################################################################################
+
+# Assumptions:
+# - LLVM toolchain is installed and is in the path (see https://apt.llvm.org/ for download instructions)
+# - You've built DGL with coverage flags turned on using `cmake --preset rocm-cov`
+# - You're running this inside of the build directory (it keeps the dgl root dir clean)
+
+# Output:
+# - coverage_report.txt
+
+# Notes:
+# - This coverage report omits third party libraries
+# - This coverage report is only generated from the C++ tests. The python tests (which 
+#   also call functions from libdgl.so) are not included.
+
+
+SCRIPT_DIR=$(realpath $(dirname $0))
+DGL_DIR=$(realpath ${SCRIPT_DIR}/..)
+
+# Add warning if llvm-cov or llvm-profdata are not in the path
+if ! command -v llvm-cov &> /dev/null; then
+  echo "llvm-cov could not be found in the path"
+  exit 1
+fi
+if ! command -v llvm-profdata &> /dev/null; then
+  echo "llvm-profdata could not be found in the path"
+  exit 1
+fi
+
+# Add warning if the build directory is not the current directory
+if [ "$(pwd)" != "${DGL_DIR}/build" ]; then
+  echo "[WARNING] You're not in the build directory"
+fi
+
+################################################################################
+# Run tests
+################################################################################
+
+${DGL_DIR}/build/runUnitTests
+
+################################################################################
+# Generate coverage report
+################################################################################
+
+# TODO do we want to collect graphbolt coverage here if we are skipping other third party libraries?
+BINARIES="${DGL_DIR}/build/libdgl.so ${DGL_DIR}/build/graphbolt/libgraphbolt_pytorch_2.6.0.so"
+
+# Collect all the profraw files
+find . -type f -name "*.profraw" > rawprofiles.list
+
+# Merge the profraw files
+llvm-profdata merge --sparse  --input-files=rawprofiles.list -o coverage.profdata
+
+# Generate the coverage report
+llvm-cov report ${BINARIES} -instr-profile=coverage.profdata --ignore-filename-regex="third_party*" | tee coverage_report.txt
+
+# llvm-cov show --instr-profile=coverage.profdata --ignore-filename-regex="third_party*" --format=html --output-dir=cov_report_llvmcov ${BINARIES} 
+
+# TODO this isn't working quite right yet
+# llvm-cov show ${BINARIES} \
+#   -instr-profile=coverage.profdata \
+#   -show-line-counts-or-regions \
+#   -format=html \
+#   -output-dir=coverage_report
+  

--- a/script/run_code_cov.sh
+++ b/script/run_code_cov.sh
@@ -9,10 +9,12 @@ set -exuo pipefail
 # Assumptions:
 # - LLVM toolchain is installed and is in the path (see https://apt.llvm.org/ for download instructions)
 # - You've built DGL with coverage flags turned on using `cmake --preset rocm-cov`
-# - You're running this inside of the build directory (it keeps the dgl root dir clean)
+# - lcov is installed and is in the path
 
 # Output:
-# - coverage_report.txt
+# - cpp_coverage_report.txt
+# - lcov_output/ (directory with html coverage report)
+# - 
 
 # Notes:
 # - This coverage report omits third party libraries
@@ -32,11 +34,17 @@ if ! command -v llvm-profdata &> /dev/null; then
   echo "llvm-profdata could not be found in the path"
   exit 1
 fi
-
-# Add warning if the build directory is not the current directory
-if [ "$(pwd)" != "${DGL_DIR}/build" ]; then
-  echo "[WARNING] You're not in the build directory"
+if ! command -v lcov &> /dev/null; then
+  echo "lcov could not be found in the path"
+  exit 1
 fi
+
+################################################################################
+# Run the python tests
+################################################################################
+
+bash ${DGL_DIR}/tests/scripts/task_unit_test_rocm.sh pytorch gpu on
+# generates lcov_pytest.info trace
 
 ################################################################################
 # Run tests
@@ -45,7 +53,7 @@ fi
 ${DGL_DIR}/build/runUnitTests
 
 ################################################################################
-# Generate coverage report
+# Generate C++ coverage report
 ################################################################################
 
 # TODO do we want to collect graphbolt coverage here if we are skipping other third party libraries?
@@ -58,23 +66,31 @@ find . -type f -name "*.profraw" > rawprofiles.list
 llvm-profdata merge --sparse  --input-files=rawprofiles.list -o coverage.profdata
 
 # Generate the coverage report for full codebase, non-cuda, and cuda-only
-llvm-cov report ${BINARIES} -instr-profile=coverage.profdata \
-  --ignore-filename-regex="third_party/"                  | tee full_coverage_report.txt
-llvm-cov report ${BINARIES} -instr-profile=coverage.profdata \
-  --ignore-filename-regex="third_party/|.*\.cu$|.*\.cuh$" | tee host_coverage_report.txt
-llvm-cov report ${BINARIES} -instr-profile=coverage.profdata \
-  --ignore-filename-regex="third_party/|.*\.cc$|.*\.h$"   | tee device_coverage_report.txt
+llvm-cov report ${BINARIES} \
+  -instr-profile=coverage.profdata \
+  --ignore-filename-regex="third_party/" | tee cpp_coverage_report.txt
 
-grep "TOTAL" *_coverage_report.txt
+# Convert to lcov format
+llvm-cov export ${BINARIES} -instr-profile=coverage.profdata -format=lcov > lcov_cpp.info
 
-# llvm-cov report ${BINARIES} -instr-profile=coverage.profdata --ignore-filename-regex="third_party*" | tee device_coverage_report.txt
+################################################################################
+# Generate the full DGL coverage report
+################################################################################
 
-# llvm-cov show --instr-profile=coverage.profdata --ignore-filename-regex="third_party*" --format=html --output-dir=cov_report_llvmcov ${BINARIES} 
+# Merge the lcov files
+lcov --ignore-errors inconsistent --ignore-errors corrupt \
+  --add-tracefile lcov_cpp.info -a lcov_pytest.info -o lcov_merged.info
+# Remove third party libraries
+lcov --ignore-errors inconsistent \
+  --remove lcov_merged.info '*/third_party/*' -o lcov_merged.info
 
-# TODO this isn't working quite right yet
-# llvm-cov show ${BINARIES} \
-#   -instr-profile=coverage.profdata \
-#   -show-line-counts-or-regions \
-#   -format=html \
-#   -output-dir=coverage_report
-  
+# Generate the coverage report
+genhtml --ignore-errors inconsistent -j lcov_merged.info -o lcov_output
+
+# Logging the import artifacts
+echo "HTML coverage report generated in lcov_output/index.html"
+echo "C++ coverage report generated in cpp_coverage_report.txt"
+echo "C++ lcov file generated in lcov_cpp.info"
+echo "Python coverage report generated in python_coverage_report.txt"
+echo "Python lcov file generated in lcov_pytest.info"
+echo "Full DGL lcov file generated in lcov_merged.info"

--- a/script/run_cpp_code_cov.sh
+++ b/script/run_cpp_code_cov.sh
@@ -57,8 +57,17 @@ find . -type f -name "*.profraw" > rawprofiles.list
 # Merge the profraw files
 llvm-profdata merge --sparse  --input-files=rawprofiles.list -o coverage.profdata
 
-# Generate the coverage report
-llvm-cov report ${BINARIES} -instr-profile=coverage.profdata --ignore-filename-regex="third_party*" | tee coverage_report.txt
+# Generate the coverage report for full codebase, non-cuda, and cuda-only
+llvm-cov report ${BINARIES} -instr-profile=coverage.profdata \
+  --ignore-filename-regex="third_party/"                  | tee full_coverage_report.txt
+llvm-cov report ${BINARIES} -instr-profile=coverage.profdata \
+  --ignore-filename-regex="third_party/|.*\.cu$|.*\.cuh$" | tee host_coverage_report.txt
+llvm-cov report ${BINARIES} -instr-profile=coverage.profdata \
+  --ignore-filename-regex="third_party/|.*\.cc$|.*\.h$"   | tee device_coverage_report.txt
+
+grep "TOTAL" *_coverage_report.txt
+
+# llvm-cov report ${BINARIES} -instr-profile=coverage.profdata --ignore-filename-regex="third_party*" | tee device_coverage_report.txt
 
 # llvm-cov show --instr-profile=coverage.profdata --ignore-filename-regex="third_party*" --format=html --output-dir=cov_report_llvmcov ${BINARIES} 
 

--- a/tests/scripts/task_unit_test_rocm.sh
+++ b/tests/scripts/task_unit_test_rocm.sh
@@ -2,8 +2,6 @@
 # Copyright Advanced Micro Devices, Inc.
 # Licensed under the Apache License Version 2.0
 
-. /opt/conda/etc/profile.d/conda.sh
-
 function fail {
     echo FAIL: $@
     exit -1
@@ -13,7 +11,7 @@ function usage {
     echo "Usage: $0 backend device [coverage (on or off)]"
 }
 
-if [ $# -ne 2 && $# -ne 3 ]; then
+if [ $# -ne 2 ] && [ $# -ne 3 ]; then
     usage
     fail "Error: must specify backend and device and optionally coverage"
 fi
@@ -47,9 +45,12 @@ if [ ${COVERAGE} == "off" ]; then
 elif [ ${COVERAGE} == "on" ]; then
   echo "pytests running with coverage"
   python3 -m pip install pytest-cov
-  python3 -m pytest --cov=dgl              --disable-warnings tests/python/test_dgl_import.py
-  python3 -m pytest --cov=dgl --cov-append --disable-warnings tests/python/common
-  python3 -m pytest --cov=dgl --cov-append --disable-warnings tests/python/$DGLBACKEND
+  python3 -m pytest --cov=dgl              --cov-report=lcov:lcov_pytest_import.info  --disable-warnings tests/python/test_dgl_import.py
+  python3 -m pytest --cov=dgl --cov-append --cov-report=lcov:lcov_pytest_common.info  --disable-warnings tests/python/common
+  python3 -m pytest --cov=dgl --cov-append --cov-report=lcov:lcov_pytest_backend.info --disable-warnings tests/python/$DGLBACKEND
+
+  # TODO need to add docs for installing lcov
+  lcov --add-tracefile lcov_pytest_backend.info -a lcov_pytest_common.info -a lcov_pytest_import.info -o lcov_pytest.info
 
   # Show summary of coverage
   coverage report -m | tee python_coverage_report.txt

--- a/tests/scripts/task_unit_test_rocm.sh
+++ b/tests/scripts/task_unit_test_rocm.sh
@@ -10,16 +10,17 @@ function fail {
 }
 
 function usage {
-    echo "Usage: $0 backend device"
+    echo "Usage: $0 backend device [coverage (on or off)]"
 }
 
-if [ $# -ne 2 ]; then
+if [ $# -ne 2 && $# -ne 3 ]; then
     usage
-    fail "Error: must specify backend and device"
+    fail "Error: must specify backend and device and optionally coverage"
 fi
 
 export DGLBACKEND=$1
 export DGLTESTDEV=$2
+export COVERAGE=${3:-"off"}
 export DGL_LIBRARY_PATH=${PWD}/build
 export PYTHONPATH=tests:${PWD}/python:$PYTHONPATH
 export DGL_DOWNLOAD_DIR=${PWD}/_download
@@ -37,9 +38,25 @@ echo "pytests running without Logger"
 
 python3 -m pip install expecttest
 
-python3 -m pytest -v --junitxml=pytest_dgl_import.xml --durations=100 --disable-warnings tests/python/test_dgl_import.py
-python3 -m pytest -v --junitxml=pytest_common.xml  --durations=100 --disable-warnings tests/python/common
-python3 -m pytest -v --junitxml=pytest_backend.xml --durations=100 --disable-warnings tests/python/$DGLBACKEND
+if [ ${COVERAGE} == "off" ]; then
+  echo "pytests running without coverage"
+  python3 -m pytest --junitxml=pytest_dgl_import.xml --durations=100 --disable-warnings tests/python/test_dgl_import.py
+  python3 -m pytest --junitxml=pytest_common.xml  --durations=100 --disable-warnings tests/python/common
+  python3 -m pytest --junitxml=pytest_backend.xml --durations=100 --disable-warnings tests/python/$DGLBACKEND
+
+elif [ ${COVERAGE} == "on" ]; then
+  echo "pytests running with coverage"
+  python3 -m pip install pytest-cov
+  python3 -m pytest --cov=dgl              --disable-warnings tests/python/test_dgl_import.py
+  python3 -m pytest --cov=dgl --cov-append --disable-warnings tests/python/common
+  python3 -m pytest --cov=dgl --cov-append --disable-warnings tests/python/$DGLBACKEND
+
+  # Show summary of coverage
+  coverage report -m | tee python_coverage_report.txt
+
+else
+  fail "Error: invalid coverage option: ${COVERAGE}"
+fi
 
 exit_code=$?
 echo "pytest exited with code: $exit_code"


### PR DESCRIPTION
## Description
This PR enables code coverage with the following:
- CMake preset for easier compilation
- New script to run C++ tests and collect llvm-cov information into three reports (full code cove, C/C++ code cov, and CUDA code cov)
- Modifications to the `tests/scripts/task_unit_test_rocm.sh` to facilitate python code coverage

For simplicity, I've only set things up to run with with llvm compilers (*for host __and__ device*).

## Checklist
Please feel free to remove inapplicable items for your PR.
- [X] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [X] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [X] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [X] All changes have test coverage
- [X] Code is well-documented
- [X] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
