### PR TITLE
[BUG] Generalize the rocm dockerfile for compatibility with rocm 6 and 7

### DIFF
--- a/docker/Dockerfile.ci_gpu_rocm
+++ b/docker/Dockerfile.ci_gpu_rocm
@@ -6,9 +6,6 @@ ARG BASE_IMAGE=rocm/pytorch:rocm7.0_ubuntu24.04_py3.12_pytorch_release_2.6.0
 FROM ${BASE_IMAGE} AS dgl_build
 
 ARG ARG_MAX_JOBS=24
-
-ENV VENV_PATH="/opt/venv"
-ENV PATH="${VENV_PATH}/bin:$PATH"
 ENV MAX_JOBS=${ARG_MAX_JOBS:-24}
 
 # Install basic tools
@@ -53,11 +50,11 @@ RUN cmake --build ${DGL_BUILD_DIR} --parallel ${MAX_JOBS}
 
 WORKDIR ${DGL_SRC_DIR}/python
 # Make sure we have wheel and build installed
-RUN ${VENV_PATH}/bin/python -m pip install build wheel
+RUN python -m pip install build wheel
 # Install an editable version of the package so we can make source changes and test them
-RUN ${VENV_PATH}/bin/python -m pip install -e .
+RUN python -m pip install -e .
 # Build the wheel file for packaging (won't update automatically with source changes)
-RUN ${VENV_PATH}/bin/python -m build --wheel
+RUN python -m build --wheel
 
 
 # Store the artifacts
@@ -65,7 +62,6 @@ RUN mkdir -p ${DGL_ARTIFACTS_DIR}
 RUN cp dist/*.whl ${DGL_ARTIFACTS_DIR}
 
 # Setup for the user
-RUN echo "source /opt/venv/bin/activate" >> ~/.bashrc
 RUN cat <<'EOT' >> ~/.bashrc
 echo "
 Welcome to the DGL CI container!

--- a/docker/Dockerfile.ci_gpu_rocm
+++ b/docker/Dockerfile.ci_gpu_rocm
@@ -5,6 +5,9 @@
 ARG BASE_IMAGE=rocm/pytorch:rocm7.0_ubuntu24.04_py3.12_pytorch_release_2.6.0
 FROM ${BASE_IMAGE} AS dgl_build
 
+# NOTE: This dockerfile **assumes** that BASE_IMAGE comes with the appropriate
+# python executable in the path.
+
 ARG ARG_MAX_JOBS=24
 ENV MAX_JOBS=${ARG_MAX_JOBS:-24}
 


### PR DESCRIPTION
## Description
This PR removes specific mention of venv from the rocm dockerfile. The pytorch docker images from rocm take different approaches in rocm 6 (conda) and 7 (venv). Since both add the approriate python to the PATH we removed any specific mention of the python env from the dockerfile.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [X] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [X] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [X] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [X] All changes have test coverage
- [X] Code is well-documented
- [X] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
