### PR TITLE
[Tests] Unskip tests that work on rocm

### DIFF
--- a/src/array/cuda/spmat_op_impl_csr.cu
+++ b/src/array/cuda/spmat_op_impl_csr.cu
@@ -630,11 +630,11 @@ CSRMatrix CSRSliceMatrix(
   // Execute SegmentMaskColKernel
   const int64_t num_rows = csr.num_rows;
 #if defined(__HIPCC__)
-  #if HIP_VERSION_MAJOR >= 7
+#if HIP_VERSION_MAJOR >= 7
   constexpr int WARP_SIZE = 64;
-  #else
+#else
   constexpr int WARP_SIZE = warpSize;
-  #endif
+#endif
 #else
   constexpr int WARP_SIZE = 32;
 #endif

--- a/src/runtime/cuda/gpu_cache.cu
+++ b/src/runtime/cuda/gpu_cache.cu
@@ -47,11 +47,11 @@ class GpuCache : public runtime::Object {
   constexpr static int set_associativity = 2;
   // WARP_SIZE Changes for __HIPCC__ result in errors. [TODO]
 #ifdef __HIPCC__
-  #if HIP_VERSION_MAJOR >= 7
+#if HIP_VERSION_MAJOR >= 7
   constexpr static int WARP_SIZE = 64;
-  #else
+#else
   constexpr static int WARP_SIZE = warpSize;
-  #endif
+#endif
 #else
   constexpr static int WARP_SIZE = 32;
 #endif

--- a/tests/backend/backend_unittest.py
+++ b/tests/backend/backend_unittest.py
@@ -20,6 +20,7 @@ def is_cuda_available():
     """Check whether CUDA is available."""
     pass
 
+
 def get_rocm_version():
     """Get the rocm version number."""
     pass

--- a/tests/backend/backend_unittest.py
+++ b/tests/backend/backend_unittest.py
@@ -20,6 +20,10 @@ def is_cuda_available():
     """Check whether CUDA is available."""
     pass
 
+def get_rocm_version():
+    """Get the rocm version number."""
+    pass
+
 
 ###############################################################################
 # Tensor functions on feature data

--- a/tests/backend/pytorch/__init__.py
+++ b/tests/backend/pytorch/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import re
+
 import torch as th
 
 
@@ -102,6 +103,7 @@ def abs(a):
 
 def seed(a):
     return th.manual_seed(a)
+
 
 def get_rocm_version():
     v = th.version.hip

--- a/tests/backend/pytorch/__init__.py
+++ b/tests/backend/pytorch/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import re
 import torch as th
 
 
@@ -101,3 +102,14 @@ def abs(a):
 
 def seed(a):
     return th.manual_seed(a)
+
+def get_rocm_version():
+    v = th.version.hip
+    if v:
+        match = re.match(r"(\d+\.\d+)", v)
+        if match:
+            return float(match.group(1))
+    match = re.search(r"\+rocm(\d+\.\d+)", th.__version__)
+    if match:
+        return float(match.group(1))
+    return 0.0

--- a/tests/python/common/sampling/test_sampling.py
+++ b/tests/python/common/sampling/test_sampling.py
@@ -1132,7 +1132,6 @@ def test_sample_neighbors_noprob():
     # _test_sample_neighbors(True)
 
 
-@unittest.skipIf(F.is_hip(), reason="Not implemented in ROCm")
 def test_sample_labors_noprob():
     _test_sample_labors(False, None)
 
@@ -1144,7 +1143,6 @@ def test_sample_neighbors_prob():
     # _test_sample_neighbors(True)
 
 
-@unittest.skipIf(F.is_hip(), reason="Not implemented in ROCm")
 def test_sample_labors_prob():
     _test_sample_labors(False, "prob")
 

--- a/tests/python/common/test_heterograph.py
+++ b/tests/python/common/test_heterograph.py
@@ -2525,6 +2525,7 @@ def test_float_cast():
             assert len(values) == len(pvalues)
             assert F.allclose(values, F.tensor(pvalues), 0, 0)
 
+
 @unittest.skipIf(F.is_hip(), reason="Not implemented in ROCm")
 @parametrize_idtype
 def test_format(idtype):

--- a/tests/python/common/test_traversal.py
+++ b/tests/python/common/test_traversal.py
@@ -19,7 +19,7 @@ def toset(x):
     # F.zerocopy_to_numpy may return a int
     return set(F.zerocopy_to_numpy(x).tolist())
 
-@unittest.skipIf(F.is_hip(), reason="Not implemented in ROCm")
+@unittest.skipIf(F.get_rocm_version() < 7.0, f"Requires ROCm >= 7.0")
 @parametrize_idtype
 def test_bfs(idtype, n=100):
     def _bfs_nx(g_nx, src):

--- a/tests/python/common/test_traversal.py
+++ b/tests/python/common/test_traversal.py
@@ -19,7 +19,7 @@ def toset(x):
     # F.zerocopy_to_numpy may return a int
     return set(F.zerocopy_to_numpy(x).tolist())
 
-@unittest.skipIf(F.get_rocm_version() < 7.0, f"Requires ROCm >= 7.0")
+@unittest.skipIf(F.is_hip() and F.get_rocm_version() < 7.0, f"Requires ROCm >= 7.0")
 @parametrize_idtype
 def test_bfs(idtype, n=100):
     def _bfs_nx(g_nx, src):

--- a/tests/python/common/test_traversal.py
+++ b/tests/python/common/test_traversal.py
@@ -19,7 +19,10 @@ def toset(x):
     # F.zerocopy_to_numpy may return a int
     return set(F.zerocopy_to_numpy(x).tolist())
 
-@unittest.skipIf(F.is_hip() and F.get_rocm_version() < 7.0, f"Requires ROCm >= 7.0")
+
+@unittest.skipIf(
+    F.is_hip() and F.get_rocm_version() < 7.0, f"Requires ROCm >= 7.0"
+)
 @parametrize_idtype
 def test_bfs(idtype, n=100):
     def _bfs_nx(g_nx, src):

--- a/tests/python/pytorch/cuda/test_nccl.py
+++ b/tests/python/pytorch/cuda/test_nccl.py
@@ -7,6 +7,7 @@ import torch.distributed as dist
 from dgl.cuda import nccl
 from dgl.partition import NDArrayPartition
 
+
 @unittest.skipIf(
     F._default_context_str == "cpu", reason="NCCL only runs on GPU."
 )
@@ -30,6 +31,7 @@ def test_nccl_sparse_push_single_remainder():
 
     dist.destroy_process_group()
 
+
 @unittest.skipIf(
     F._default_context_str == "cpu", reason="NCCL only runs on GPU."
 )
@@ -52,6 +54,7 @@ def test_nccl_sparse_pull_single_remainder():
     assert F.array_equal(rv, exp_rv)
 
     dist.destroy_process_group()
+
 
 @unittest.skipIf(
     F._default_context_str == "cpu", reason="NCCL only runs on GPU."
@@ -78,6 +81,7 @@ def test_nccl_sparse_push_single_range():
     assert F.array_equal(rv, value)
 
     dist.destroy_process_group()
+
 
 @unittest.skipIf(
     F._default_context_str == "cpu", reason="NCCL only runs on GPU."

--- a/tests/python/pytorch/nn/test_nn.py
+++ b/tests/python/pytorch/nn/test_nn.py
@@ -2713,38 +2713,63 @@ def test_conv_with_zero_nodes_bugfix_7894(residual):
     node_features = {
         "user": torch.randn(num_nodes_dict["user"], feat_dim),
         "item": torch.randn(num_nodes_dict["item"], feat_dim),
-        "tag": torch.randn(num_nodes_dict["tag"], feat_dim), 
+        "tag": torch.randn(num_nodes_dict["tag"], feat_dim),
     }
     edge_features = {
-        ("user", "buys", "item"): torch.randn(g.num_edges(("user", "buys", "item")), feat_dim),
-        ("user", "likes", "tag"): torch.randn(g.num_edges(("user", "likes", "tag")), feat_dim),
+        ("user", "buys", "item"): torch.randn(
+            g.num_edges(("user", "buys", "item")), feat_dim
+        ),
+        ("user", "likes", "tag"): torch.randn(
+            g.num_edges(("user", "likes", "tag")), feat_dim
+        ),
     }
 
     # Test GATConv with zero nodes in "tag" type
-    conv = nn.HeteroGraphConv({
-        ("user", "buys", "item"): nn.GATConv(16, 2, num_heads=2, residual=residual),
-        ("user", "likes", "tag"): nn.GATConv(16, 2, num_heads=2, residual=residual),
-    }, aggregate="sum")
+    conv = nn.HeteroGraphConv(
+        {
+            ("user", "buys", "item"): nn.GATConv(
+                16, 2, num_heads=2, residual=residual
+            ),
+            ("user", "likes", "tag"): nn.GATConv(
+                16, 2, num_heads=2, residual=residual
+            ),
+        },
+        aggregate="sum"
+    )
     out = conv(g, node_features)
     assert out["item"].shape == (10, 2, 2)
     assert out["tag"].shape == (0, 2, 2)
     assert "user" not in out
 
     # Test GATv2Conv with zero nodes in "tag" type
-    conv_v2 = nn.HeteroGraphConv({
-        ("user", "buys", "item"): nn.GATv2Conv(16, 2, num_heads=2, residual=residual),
-        ("user", "likes", "tag"): nn.GATv2Conv(16, 2, num_heads=2, residual=residual),
-    }, aggregate="sum")
+    conv_v2 = nn.HeteroGraphConv(
+        {
+            ("user", "buys", "item"): nn.GATv2Conv(
+                16, 2, num_heads=2, residual=residual
+            ),
+            ("user", "likes", "tag"): nn.GATv2Conv(
+                16, 2, num_heads=2, residual=residual
+            ),
+        }, 
+        aggregate="sum"
+    )
     out_v2 = conv_v2(g, node_features)
     assert out_v2["item"].shape == (10, 2, 2)
     assert out_v2["tag"].shape == (0, 2, 2)
     assert "user" not in out_v2
 
     # Test EdgeGATConv with zero nodes in "tag" type
-    edge_conv = nn.HeteroGraphConv({
-        ("user", "buys", "item"): nn.EdgeGATConv(16, 16, 2, num_heads=2, residual=residual),
-        ("user", "likes", "tag"): nn.EdgeGATConv(16, 16, 2, num_heads=2, residual=residual),
-    }, aggregate="sum")
+    edge_conv = nn.HeteroGraphConv(
+        {
+            ("user", "buys", "item"): nn.EdgeGATConv(
+                16, 16, 2, num_heads=2, residual=residual
+            ),
+            ("user", "likes", "tag"): nn.EdgeGATConv(
+                16, 16, 2, num_heads=2, residual=residual
+            ),
+        },
+        aggregate="sum"
+    )
     mod_kwargs = {
         "buys": {"edge_feat": edge_features[("user", "buys", "item")]},
         "likes": {"edge_feat": edge_features[("user", "likes", "tag")]},

--- a/tests/python/pytorch/nn/test_nn.py
+++ b/tests/python/pytorch/nn/test_nn.py
@@ -2734,7 +2734,7 @@ def test_conv_with_zero_nodes_bugfix_7894(residual):
                 16, 2, num_heads=2, residual=residual
             ),
         },
-        aggregate="sum"
+        aggregate="sum",
     )
     out = conv(g, node_features)
     assert out["item"].shape == (10, 2, 2)
@@ -2750,8 +2750,8 @@ def test_conv_with_zero_nodes_bugfix_7894(residual):
             ("user", "likes", "tag"): nn.GATv2Conv(
                 16, 2, num_heads=2, residual=residual
             ),
-        }, 
-        aggregate="sum"
+        },
+        aggregate="sum",
     )
     out_v2 = conv_v2(g, node_features)
     assert out_v2["item"].shape == (10, 2, 2)
@@ -2768,7 +2768,7 @@ def test_conv_with_zero_nodes_bugfix_7894(residual):
                 16, 16, 2, num_heads=2, residual=residual
             ),
         },
-        aggregate="sum"
+        aggregate="sum",
     )
     mod_kwargs = {
         "buys": {"edge_feat": edge_features[("user", "buys", "item")]},

--- a/tests/python/pytorch/nn/test_sparse_emb.py
+++ b/tests/python/pytorch/nn/test_sparse_emb.py
@@ -64,6 +64,7 @@ def start_sparse_worker(rank, world_size, test, args):
     th.distributed.barrier()
     th.distributed.destroy_process_group()
 
+
 @unittest.skipIf(F.is_hip(), reason="Not implemented in ROCm")
 @unittest.skipIf(os.name == "nt", reason="Do not support windows yet")
 @pytest.mark.parametrize("num_workers", [1, 2, 3])
@@ -88,6 +89,7 @@ def test_multiprocess_sparse_emb_get_set(num_workers):
         p.join()
     for p in worker_list:
         assert p.exitcode == 0
+
 
 @unittest.skipIf(F.is_hip(), reason="Not implemented in ROCm")
 @unittest.skipIf(os.name == "nt", reason="Do not support windows yet")

--- a/tests/python/pytorch/optim/test_optim.py
+++ b/tests/python/pytorch/optim/test_optim.py
@@ -10,7 +10,6 @@ from dgl.nn import NodeEmbedding
 from dgl.optim import SparseAdagrad, SparseAdam
 
 
-@unittest.skipIf(F.is_hip(), reason="Not implemented in ROCm")
 @unittest.skipIf(os.name == "nt", reason="Do not support windows yet")
 @pytest.mark.parametrize("emb_dim", [1, 4, 101, 1024])
 def test_sparse_adam(emb_dim):
@@ -50,7 +49,6 @@ def test_sparse_adam(emb_dim):
     # DGL sparseAdam use a per embedding step
 
 
-@unittest.skipIf(F.is_hip(), reason="Not implemented in ROCm")
 @unittest.skipIf(os.name == "nt", reason="Do not support windows yet")
 @pytest.mark.parametrize("use_uva", [False, True, None])
 @pytest.mark.parametrize("emb_dim", [1, 4, 101, 1024])
@@ -643,7 +641,6 @@ def start_sparse_adam_state_dict_worker(
     th.distributed.barrier()
 
 
-@unittest.skipIf(F.is_hip(), reason="Not implemented in ROCm")
 @unittest.skipIf(os.name == "nt", reason="Do not support windows yet")
 @unittest.skipIf(F.ctx().type == "cpu", reason="gpu only test")
 @pytest.mark.parametrize("num_workers", [1, 2, 4, 8])

--- a/tests/python/pytorch/optim/test_optim.py
+++ b/tests/python/pytorch/optim/test_optim.py
@@ -282,7 +282,9 @@ def start_torch_adam_worker(
             lr=0.01,
         )
     else:
-        torch_adam = th.optim.SparseAdam(list(torch_emb.module.parameters()), lr=0.01)
+        torch_adam = th.optim.SparseAdam(
+            list(torch_emb.module.parameters()), lr=0.01
+        )
 
     th.manual_seed(rank)
     if zero_comm:
@@ -411,7 +413,9 @@ def test_multiprocess_sparse_adam(num_workers, backend, zero_comm):
 
 
 @unittest.skipIf(os.name == "nt", reason="Do not support windows yet")
-@unittest.skipIf(F.ctx().type == "cpu", reason="cuda tensor is not supported for cpu")
+@unittest.skipIf(
+    F.ctx().type == "cpu", reason="cuda tensor is not supported for cpu"
+)
 @pytest.mark.parametrize("num_workers", [2, 4, 8])
 def test_multiprocess_sparse_adam_cuda_tensor(num_workers):
     if F.ctx().type == "cpu":
@@ -547,7 +551,9 @@ def test_multiprocess_sparse_adam_zero_step(num_workers, backend):
 
 
 @unittest.skipIf(os.name == "nt", reason="Do not support windows yet")
-@unittest.skipIf(F.ctx().type == "cpu", reason="cuda tensor is not supported for cpu")
+@unittest.skipIf(
+    F.ctx().type == "cpu", reason="cuda tensor is not supported for cpu"
+)
 @pytest.mark.parametrize("num_workers", [2, 4, 8])
 def test_multiprocess_sparse_adam_zero_step_cuda_tensor(num_workers):
     if F.ctx().type == "cuda" and th.cuda.device_count() < num_workers:


### PR DESCRIPTION
## Description
The following functions are currently marked as unsupported - 
`format  
multiprocess_sparse_adam_state_dict 
half_spmm 
segment_mm 
gather_mm_idx_b 
sample_labors_prob 
sample_labors_noprob 
Bfs 
sparse_adam`

Tested the above functions on mi300x and mi250x and also with rocm6.4.3 and rocm7.  
The following functions pass and are unskipped  - 
` multiprocess_sparse_adam_state_dict 
sample_labors_prob 
sample_labors_noprob 
sparse_adam
sparse_adam_uva
test_multiprocess_sparse_adam_state_dict`

`bfs` passes with rocm7 but fails with rocm6.4.3 - added a condition to skip test based on rocm version

The following functions are still unsupported - 
`format
half_spmm 
segment_mm 
gather_mm_idx_b`
## Checklist
Please feel free to remove inapplicable items for your PR.
- [X] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [X] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [X] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [NA] All changes have test coverage
- [NA] Code is well-documented
- [X] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [NA] Related issue is referred in this PR
- [NA] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).


